### PR TITLE
Develop

### DIFF
--- a/MaxLib.WebServer.Test/Testing/TestTestTask.cs
+++ b/MaxLib.WebServer.Test/Testing/TestTestTask.cs
@@ -12,7 +12,7 @@ namespace MaxLib.WebServer.Test.Testing
         {
             var server = new TestWebServer();
             var test = new TestTask(server);
-            test.Task.Document.RequestHeader.Cookie.AddedCookies.Add(
+            test.Task.Request.Cookie.AddedCookies.Add(
                 "test1",
                 new MaxLib.WebServer.HttpCookie.Cookie("test2", "test3"));
             var added = test.GetAddedCookies().ToArray();

--- a/MaxLib.WebServer/Api/ApiService.cs
+++ b/MaxLib.WebServer/Api/ApiService.cs
@@ -25,19 +25,19 @@ namespace MaxLib.WebServer.Api
         public override bool CanWorkWith(WebProgressTask task)
         {
             _ = task ?? throw new ArgumentNullException(nameof(task));
-            return task.Document.RequestHeader.Location.StartsUrlWith(endpoint, IgnoreCase);
+            return task.Request.Location.StartsUrlWith(endpoint, IgnoreCase);
         }
 
         public override async Task ProgressTask(WebProgressTask task)
         {
             _ = task ?? throw new ArgumentNullException(nameof(task));
-            var tiles = task.Document.RequestHeader.Location.DocumentPathTiles;
+            var tiles = task.Request.Location.DocumentPathTiles;
             var location = new string[tiles.Length - endpoint.Length];
             Array.Copy(tiles, endpoint.Length, location, 0, location.Length);
             var data = await HandleRequest(task, location);
             if (data != null)
                 task.Document.DataSources.Add(data);
-            else task.Document.ResponseHeader.StatusCode = HttpStateCode.InternalServerError;
+            else task.Response.StatusCode = HttpStateCode.InternalServerError;
         }
     }
 }

--- a/MaxLib.WebServer/Api/Rest/RestApiService.cs
+++ b/MaxLib.WebServer/Api/Rest/RestApiService.cs
@@ -33,14 +33,14 @@ namespace MaxLib.WebServer.Api.Rest
         {
             _ = task ?? throw new ArgumentNullException(nameof(task));
             _ = location ?? throw new ArgumentNullException(nameof(location));
-            return new RestQueryArgs(location, task.Document.RequestHeader.Location.GetParameter, task.Document.RequestHeader.Post);
+            return new RestQueryArgs(location, task.Request.Location.GetParameter, task.Request.Post);
         }
 
         protected virtual HttpDataSource NoEndpoint(WebProgressTask task, RestQueryArgs args)
         {
             _ = task ?? throw new ArgumentNullException(nameof(task));
             _ = args ?? throw new ArgumentNullException(nameof(args));
-            task.Document.ResponseHeader.StatusCode = HttpStateCode.NotFound;
+            task.Response.StatusCode = HttpStateCode.NotFound;
             return new HttpStringDataSource("no endpoint");
         }
     }

--- a/MaxLib.WebServer/Chunked/ChunkedResponseCreator.cs
+++ b/MaxLib.WebServer/Chunked/ChunkedResponseCreator.cs
@@ -26,8 +26,8 @@ namespace MaxLib.WebServer.Chunked
 
         public override async Task ProgressTask(WebProgressTask task)
         {
-            var request = task.Document.RequestHeader;
-            var response = task.Document.ResponseHeader;
+            var request = task.Request;
+            var response = task.Response;
             response.FieldContentType = task.Document.PrimaryMime;
             response.SetActualDate();
             response.HttpProtocol = request.HttpProtocol;

--- a/MaxLib.WebServer/Chunked/ChunkedSender.cs
+++ b/MaxLib.WebServer/Chunked/ChunkedSender.cs
@@ -28,7 +28,7 @@ namespace MaxLib.WebServer.Chunked
 
         public override async Task ProgressTask(WebProgressTask task)
         {
-            var header = task.Document.ResponseHeader;
+            var header = task.Response;
             var stream = task.NetworkStream;
             var writer = new StreamWriter(stream);
             await writer.WriteAsync(header.HttpProtocol);
@@ -43,7 +43,7 @@ namespace MaxLib.WebServer.Chunked
                 await writer.WriteAsync(": ");
                 await writer.WriteLineAsync(e.Value);
             }
-            foreach (var cookie in task.Document.RequestHeader.Cookie.AddedCookies) //Cookies
+            foreach (var cookie in task.Request.Cookie.AddedCookies) //Cookies
             {
                 await writer.WriteAsync("Set-Cookie: ");
                 await writer.WriteLineAsync(cookie.ToString());

--- a/MaxLib.WebServer/HttpConnection.cs
+++ b/MaxLib.WebServer/HttpConnection.cs
@@ -3,17 +3,19 @@ using System.Collections.Generic;
 using System.IO;
 using System.Net.Sockets;
 
+#nullable enable
+
 namespace MaxLib.WebServer
 {
     [Serializable]
     public class HttpConnection
     {
-        public string Ip { get; set; }
+        public string? Ip { get; set; }
 
-        public TcpClient NetworkClient { get; set; }
+        public TcpClient? NetworkClient { get; set; }
 
-        public Stream NetworkStream { get; set; }
+        public Stream? NetworkStream { get; set; }
 
-        public int LastWorkTime { get; set; }
+        public int LastWorkTime { get; set; } = -1;
     }
 }

--- a/MaxLib.WebServer/HttpConnection.cs
+++ b/MaxLib.WebServer/HttpConnection.cs
@@ -8,8 +8,6 @@ namespace MaxLib.WebServer
     [Serializable]
     public class HttpConnection
     {
-        public byte[] ConnectionKey { get; set; }
-
         public string Ip { get; set; }
 
         public TcpClient NetworkClient { get; set; }
@@ -17,11 +15,5 @@ namespace MaxLib.WebServer
         public Stream NetworkStream { get; set; }
 
         public int LastWorkTime { get; set; }
-
-        public Dictionary<object, object> SessionInformation { get; private set; } 
-            = new Dictionary<object, object>();
-
-        public void AlwaysSyncSessionInformation(Dictionary<object, object> information)
-            => SessionInformation = information ?? throw new ArgumentNullException(nameof(information));
     }
 }

--- a/MaxLib.WebServer/HttpCookie.cs
+++ b/MaxLib.WebServer/HttpCookie.cs
@@ -3,6 +3,8 @@ using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Text;
 
+#nullable enable
+
 namespace MaxLib.WebServer
 {
     [Serializable]
@@ -68,7 +70,7 @@ namespace MaxLib.WebServer
             }
         }
 
-        public string CompleteRequestCookie { get; private set; }
+        public string CompleteRequestCookie { get; private set; } = "";
 
         public Dictionary<string, Cookie> AddedCookies { get; }
 

--- a/MaxLib.WebServer/HttpDataSource.cs
+++ b/MaxLib.WebServer/HttpDataSource.cs
@@ -3,6 +3,8 @@ using System;
 using System.IO;
 using System.Threading.Tasks;
 
+#nullable enable
+
 namespace MaxLib.WebServer
 {
     [Serializable]
@@ -43,7 +45,8 @@ namespace MaxLib.WebServer
         {
             _ = stream ?? throw new ArgumentNullException(nameof(stream));
             if (start < 0) throw new ArgumentOutOfRangeException(nameof(start));
-            if (Length() != null && start >= Length().Value)
+            var length = Length();
+            if (length != null && start >= length.Value)
                 throw new ArgumentOutOfRangeException(nameof(start));
             if (stop != null && stop < start) throw new ArgumentOutOfRangeException(nameof(stop));
             return await WriteStreamInternal(stream, start, stop);

--- a/MaxLib.WebServer/HttpDocument.cs
+++ b/MaxLib.WebServer/HttpDocument.cs
@@ -16,9 +16,12 @@ namespace MaxLib.WebServer
 
         public string PrimaryEncoding { get; set; } = null;
 
-        public HttpRequestHeader RequestHeader { get; set; }
+        [Obsolete("Use WebProgressTask.Request. this will be removed in a future release.")]
+        public HttpRequestHeader RequestHeader { get; set; } = new HttpRequestHeader();
 
-        public HttpResponseHeader ResponseHeader { get; set; }
+        [Obsolete("Use WebProgressTask.Response. this will be removed in a future release.")]
+        public HttpResponseHeader ResponseHeader { get; set; } = new HttpResponseHeader();
+        
         public Dictionary<object, object> Information { get; } = new Dictionary<object, object>();
 
         public object this[object identifer]

--- a/MaxLib.WebServer/HttpDocument.cs
+++ b/MaxLib.WebServer/HttpDocument.cs
@@ -2,6 +2,8 @@
 using System.Collections.Generic;
 using System.Linq;
 
+#nullable enable
+
 namespace MaxLib.WebServer
 {
     [Serializable]
@@ -9,22 +11,22 @@ namespace MaxLib.WebServer
     {
         public List<HttpDataSource> DataSources { get; } = new List<HttpDataSource>();
 
-        public string PrimaryMime
+        public string? PrimaryMime
         {
             get { return DataSources.Count == 0 ? null : DataSources[0].MimeType; }
         }
 
-        public string PrimaryEncoding { get; set; } = null;
+        public string? PrimaryEncoding { get; set; } = null;
 
         [Obsolete("Use WebProgressTask.Request. this will be removed in a future release.")]
         public HttpRequestHeader RequestHeader { get; set; } = new HttpRequestHeader();
 
         [Obsolete("Use WebProgressTask.Response. this will be removed in a future release.")]
         public HttpResponseHeader ResponseHeader { get; set; } = new HttpResponseHeader();
-        
-        public Dictionary<object, object> Information { get; } = new Dictionary<object, object>();
 
-        public object this[object identifer]
+        public Dictionary<object?, object?> Information { get; } = new Dictionary<object?, object?>();
+
+        public object? this[object? identifer]
         {
             get => Information[identifer];
             set => Information[identifer] = value;

--- a/MaxLib.WebServer/HttpFileDataSource.cs
+++ b/MaxLib.WebServer/HttpFileDataSource.cs
@@ -3,15 +3,17 @@ using System;
 using System.IO;
 using System.Threading.Tasks;
 
+#nullable enable
+
 namespace MaxLib.WebServer
 {
     [Serializable]
     public class HttpFileDataSource : HttpDataSource
     {
-        public FileStream File { get; private set; }
+        public FileStream? File { get; private set; }
 
-        private string path = null;
-        public virtual string Path
+        private string? path = null;
+        public virtual string? Path
         {
             get => path;
             set
@@ -37,7 +39,7 @@ namespace MaxLib.WebServer
 
         public override bool CanProvideData => true;
 
-        public HttpFileDataSource(string path, bool readOnly = true)
+        public HttpFileDataSource(string? path, bool readOnly = true)
         {
             ReadOnly = readOnly;
             Path = path;
@@ -54,6 +56,8 @@ namespace MaxLib.WebServer
         protected override async Task<long> WriteStreamInternal(Stream stream, long start, long? stop)
         {
             await Task.CompletedTask;
+            if (File == null)
+                return 0;
             File.Position = start;
             using (var skip = new SkipableStream(File, 0))
             {
@@ -75,6 +79,8 @@ namespace MaxLib.WebServer
             await Task.CompletedTask;
             if (ReadOnly)
                 throw new NotSupportedException();
+            if (File == null)
+                return 0;
             File.Position = 0;
             using (var skip = new SkipableStream(File, 0))
             {

--- a/MaxLib.WebServer/HttpHeader.cs
+++ b/MaxLib.WebServer/HttpHeader.cs
@@ -1,6 +1,8 @@
 ﻿using System;
 using System.Collections.Generic;
 
+#nullable enable
+
 namespace MaxLib.WebServer
 {
     [Serializable]
@@ -20,11 +22,33 @@ namespace MaxLib.WebServer
 
         public Dictionary<string, string> HeaderParameter { get; } = new Dictionary<string, string>();
 
-        public void SetHeader(IEnumerable<(string, string)> headers)
+        public string? GetHeader(string key)
+        {
+            _ = key ?? throw new ArgumentNullException(nameof(key));
+            return HeaderParameter.TryGetValue(key, out string value) ? value : null;
+        }
+
+        public void SetHeader(IEnumerable<(string, string?)> headers)
         {
             _ = headers ?? throw new ArgumentNullException(nameof(headers));
             foreach (var (key, value) in headers)
+                if (value != null)
+                    HeaderParameter[key] = value;
+                else HeaderParameter.Remove(key);
+        }
+
+        public void SetHeader(params (string, string?)[] header)
+        {
+            _ = header ?? throw new ArgumentNullException(nameof(header));
+            SetHeader(headers: header);
+        }
+
+        public void SetHeader(string key, string? value)
+        {
+            _ = key ?? throw new ArgumentNullException(nameof(key));
+            if (value != null)
                 HeaderParameter[key] = value;
+            else HeaderParameter.Remove(key);
         }
 
         private string protocolMethod = HttpProtocollMethod.Get;

--- a/MaxLib.WebServer/HttpLocation.cs
+++ b/MaxLib.WebServer/HttpLocation.cs
@@ -3,6 +3,8 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text.RegularExpressions;
 
+#nullable enable
+
 namespace MaxLib.WebServer
 {
     [Serializable]
@@ -56,8 +58,11 @@ namespace MaxLib.WebServer
 
         public HttpLocation(string url)
         {
-            _ = url ?? throw new ArgumentNullException(nameof(url));
+            Url = url ?? throw new ArgumentNullException(nameof(url));
             GetParameter = new Dictionary<string, string>();
+            DocumentPath = "";
+            DocumentPathTiles = new string[0];
+            CompleteGet = "";
             SetLocation(url);
         }
 

--- a/MaxLib.WebServer/HttpPost.cs
+++ b/MaxLib.WebServer/HttpPost.cs
@@ -2,6 +2,8 @@
 using System.Collections.Generic;
 using System.Text.RegularExpressions;
 
+#nullable enable
+
 namespace MaxLib.WebServer
 {
     [Serializable]
@@ -9,11 +11,11 @@ namespace MaxLib.WebServer
     {
         public string CompletePost { get; private set; }
 
-        public string MimeType { get; private set; }
+        public string? MimeType { get; private set; }
 
         public Dictionary<string, string> PostParameter { get; }
 
-        public virtual void SetPost(string post, string mime)
+        public virtual void SetPost(string post, string? mime)
         {
             CompletePost = post ?? throw new ArgumentNullException("Post");
 
@@ -73,9 +75,9 @@ namespace MaxLib.WebServer
 
         }
 
-        public HttpPost(string post, string mime)
+        public HttpPost(string post, string? mime)
         {
-            _ = post ?? throw new ArgumentNullException(nameof(post));
+            CompletePost = post ?? throw new ArgumentNullException(nameof(post));
             PostParameter = new Dictionary<string, string>();
             SetPost(post, mime);
         }

--- a/MaxLib.WebServer/HttpProtocollDefinition.cs
+++ b/MaxLib.WebServer/HttpProtocollDefinition.cs
@@ -1,6 +1,8 @@
 ﻿using System;
 using System.Linq;
 
+#nullable enable
+
 namespace MaxLib.WebServer
 {
     public static class HttpProtocollDefinition

--- a/MaxLib.WebServer/HttpRequestHeader.cs
+++ b/MaxLib.WebServer/HttpRequestHeader.cs
@@ -1,6 +1,8 @@
 ﻿using System;
 using System.Collections.Generic;
 
+#nullable enable
+
 namespace MaxLib.WebServer
 {
     [Serializable]
@@ -27,10 +29,10 @@ namespace MaxLib.WebServer
         public HttpConnectionType FieldConnection { get; set; } = HttpConnectionType.Close;
         public HttpCookie Cookie { get; } = new HttpCookie("");
 
-        public string FieldUserAgent
+        public string? FieldUserAgent
         {
-            get => HeaderParameter.TryGetValue("User-Agent", out string value) ? value : null;
-            set => HeaderParameter["User-Agent"] = value;
+            get => GetHeader("User-Agent");
+            set => SetHeader("User-Agent", value);
         }
     }
 }

--- a/MaxLib.WebServer/HttpResponseHeader.cs
+++ b/MaxLib.WebServer/HttpResponseHeader.cs
@@ -1,5 +1,7 @@
 ﻿using System;
 
+#nullable enable
+
 namespace MaxLib.WebServer
 {
     [Serializable]
@@ -7,28 +9,28 @@ namespace MaxLib.WebServer
     {
         public HttpStateCode StatusCode { get; set; } = HttpStateCode.OK;
 
-        public string FieldLocation
+        public string? FieldLocation
         {
-            get => HeaderParameter.TryGetValue("Location", out string value) ? value : null;
-            set => HeaderParameter["Location"] = value;
+            get => GetHeader("Location");
+            set => SetHeader("Location", value);
         }
 
-        public string FieldDate
+        public string? FieldDate
         {
-            get => HeaderParameter.TryGetValue("Date", out string value) ? value : null;
-            set => HeaderParameter["Date"] = value;
+            get => GetHeader("Date");
+            set => SetHeader("Date", value);
         }
 
-        public string FieldLastModified
+        public string? FieldLastModified
         {
-            get => HeaderParameter.TryGetValue("Last-Modified", out string value) ? value : null;
-            set => HeaderParameter["Last-Modified"] = value;
+            get => GetHeader("Last-Modified");
+            set => SetHeader("Last-Modified", value);
         }
 
-        public string FieldContentType
+        public string? FieldContentType
         {
-            get => HeaderParameter.TryGetValue("Content-Type", out string value) ? value : null;
-            set => HeaderParameter["Content-Type"] = value;
+            get => GetHeader("Content-Type");
+            set => SetHeader("Content-Type", value);
         }
 
         public virtual void SetActualDate()

--- a/MaxLib.WebServer/HttpStreamDataSource.cs
+++ b/MaxLib.WebServer/HttpStreamDataSource.cs
@@ -3,6 +3,8 @@ using System;
 using System.IO;
 using System.Threading.Tasks;
 
+#nullable enable
+
 namespace MaxLib.WebServer
 {
     [Serializable]

--- a/MaxLib.WebServer/HttpStringDataSource.cs
+++ b/MaxLib.WebServer/HttpStringDataSource.cs
@@ -4,6 +4,8 @@ using System.IO;
 using System.Text;
 using System.Threading.Tasks;
 
+#nullable enable
+
 namespace MaxLib.WebServer
 {
     [Serializable]
@@ -22,7 +24,7 @@ namespace MaxLib.WebServer
             get => encoding;
             set
             {
-                encoding = value;
+                encoding = value ?? throw new ArgumentNullException(nameof(value));
                 Encoder = Encoding.GetEncoding(value);
             }
         }

--- a/MaxLib.WebServer/Lazy/LazyTask.cs
+++ b/MaxLib.WebServer/Lazy/LazyTask.cs
@@ -26,7 +26,7 @@ namespace MaxLib.WebServer.Lazy
             _ = task ?? throw new ArgumentNullException(nameof(task));
             Server = task.Server;
             Connection = task.Connection;
-            Header = task.Document.RequestHeader;
+            Header = task.Request;
             Information = task.Document.Information;
         }
     }

--- a/MaxLib.WebServer/MaxLib.WebServer.csproj.include
+++ b/MaxLib.WebServer/MaxLib.WebServer.csproj.include
@@ -2,7 +2,7 @@
 <Project>
   
   <PropertyGroup>
-    <Version>2.0.0</Version>
+    <Version>2.1.0</Version>
     <AssemblyVersion>$(Version).0</AssemblyVersion>
     <FileVersion>$(Version).0</FileVersion>
   </PropertyGroup>

--- a/MaxLib.WebServer/MimeType.cs
+++ b/MaxLib.WebServer/MimeType.cs
@@ -1,5 +1,7 @@
 ﻿using System;
 
+#nullable enable
+
 namespace MaxLib.WebServer
 {
     /// <summary>

--- a/MaxLib.WebServer/MultipartRanges.cs
+++ b/MaxLib.WebServer/MultipartRanges.cs
@@ -5,6 +5,8 @@ using System.IO;
 using System.Text;
 using System.Threading.Tasks;
 
+#nullable enable
+
 namespace MaxLib.WebServer
 {
     [Serializable]
@@ -55,13 +57,13 @@ namespace MaxLib.WebServer
         List<Range> ranges = new List<Range>();
 
         [Obsolete("Use MultipartRanges(Stream, HttpRequestHeader, HttpResponseHeader, string) instead. This will be removed in a future release.")]
-        public MultipartRanges(Stream stream, HttpDocument document, string mime)
+        public MultipartRanges(Stream stream, HttpDocument document, string? mime)
             : this(stream, document.RequestHeader, document.ResponseHeader, mime)
         {
 
         }
 
-        public MultipartRanges(Stream stream, WebProgressTask task, string mime)
+        public MultipartRanges(Stream stream, WebProgressTask task, string? mime)
             : this(
                 stream,
                 task?.Request ?? throw new ArgumentNullException(nameof(task.Request)),
@@ -73,12 +75,12 @@ namespace MaxLib.WebServer
         }
 
         public MultipartRanges(Stream stream, HttpRequestHeader request, 
-            HttpResponseHeader response, string mime)
+            HttpResponseHeader response, string? mime)
         {
             _ = request ?? throw new ArgumentNullException(nameof(request));
             this.response = response ?? throw new ArgumentNullException(nameof(response));
             baseStream = stream ?? throw new ArgumentNullException(nameof(stream));
-            MimeType = mime;
+            MimeType = string.IsNullOrWhiteSpace(mime) ? WebServer.MimeType.TextHtml : mime;
 
             response.HeaderParameter["Accept-Ranges"] = "bytes";
             if (request.HeaderParameter.ContainsKey("Range"))

--- a/MaxLib.WebServer/SSL/SecureWebServer.cs
+++ b/MaxLib.WebServer/SSL/SecureWebServer.cs
@@ -76,11 +76,13 @@ namespace MaxLib.WebServer.SSL
                 return;
             }
             //prepare session
-            var connection = CreateRandomConnection();
-            connection.NetworkClient = client;
-            connection.Ip = client.Client.RemoteEndPoint is IPEndPoint iPEndPoint
-                ? iPEndPoint.Address.ToString()
-                : client.Client.RemoteEndPoint.ToString();
+            var connection = new HttpConnection()
+            {
+                NetworkClient = client,
+                Ip = client.Client.RemoteEndPoint is IPEndPoint iPEndPoint
+                    ? iPEndPoint.Address.ToString()
+                    : client.Client.RemoteEndPoint.ToString(),
+            };
             AllConnections.Add(connection);
             //listen to connection
             _ = Task.Run(async () =>

--- a/MaxLib.WebServer/Server.cs
+++ b/MaxLib.WebServer/Server.cs
@@ -7,6 +7,7 @@ using System.Threading;
 using System.Threading.Tasks;
 
 //Source: Wikipedia, SelfHTML
+#nullable enable
 
 namespace MaxLib.WebServer
 {
@@ -18,8 +19,8 @@ namespace MaxLib.WebServer
 
         //Serveraktivitäten
 
-        protected TcpListener Listener;
-        protected Thread ServerThread;
+        protected TcpListener? Listener;
+        protected Thread? ServerThread;
         public bool ServerExecution { get; protected set; }
         public SyncedList<HttpConnection> KeepAliveConnections { get; } = new SyncedList<HttpConnection>();
         public SyncedList<HttpConnection> AllConnections { get; } = new SyncedList<HttpConnection>();
@@ -86,11 +87,13 @@ namespace MaxLib.WebServer
         {
             WebServerLog.Add(ServerLogType.Information, GetType(), "StartUp", "Stopped Server");
             ServerExecution = false;
-            ServerThread.Join();
+            ServerThread?.Join();
         }
         
         protected virtual void ServerMainTask()
         {
+            if (Listener == null)
+                return;
             WebServerLog.Add(ServerLogType.Information, GetType(), "StartUp", "Server succesfuly started");
             var watch = new Stopwatch();
             while (ServerExecution)
@@ -110,12 +113,16 @@ namespace MaxLib.WebServer
                     HttpConnection kas;
                     try { kas = KeepAliveConnections[i]; }
                     catch { continue; }
-                    if (kas == null) continue;
+                    if (kas == null) 
+                        continue;
 
-                    if (!kas.NetworkClient.Connected || (kas.LastWorkTime != -1 &&
-                        kas.LastWorkTime + Settings.ConnectionTimeout < Environment.TickCount))
+                    if ((kas.NetworkClient != null && !kas.NetworkClient.Connected) || 
+                        (kas.LastWorkTime != -1 &&
+                            kas.LastWorkTime + Settings.ConnectionTimeout < Environment.TickCount
+                        )
+                    )
                     {
-                        kas.NetworkClient.Close();
+                        kas.NetworkClient?.Close();
                         kas.NetworkStream?.Dispose();
                         AllConnections.Remove(kas);
                         KeepAliveConnections.Remove(kas);
@@ -123,7 +130,9 @@ namespace MaxLib.WebServer
                         continue;
                     }
 
-                    if (kas.NetworkClient.Available > 0 && kas.LastWorkTime != -1)
+                    if (kas.NetworkClient != null && kas.NetworkClient.Available > 0 && 
+                        kas.LastWorkTime != -1
+                    )
                     {
                         _ = Task.Run(() => SafeClientStartListen(kas));
                     }
@@ -138,7 +147,7 @@ namespace MaxLib.WebServer
             watch.Stop();
             Listener.Stop();
             for (int i = 0; i < AllConnections.Count; ++i) 
-                AllConnections[i].NetworkClient.Close();
+                AllConnections[i].NetworkClient?.Close();
             AllConnections.Clear();
             KeepAliveConnections.Clear();
             WebServerLog.Add(ServerLogType.Information, GetType(), "StartUp", "Server succesfuly stopped");
@@ -180,7 +189,7 @@ namespace MaxLib.WebServer
         protected virtual async Task ClientStartListen(HttpConnection connection)
         {
             connection.LastWorkTime = -1;
-            if (connection.NetworkClient.Connected)
+            if (connection.NetworkClient != null && connection.NetworkClient.Connected)
             {
                 WebServerLog.Add(ServerLogType.Information, GetType(), "Connection", "Listen to Connection {0}", 
                     connection.NetworkClient.Client.RemoteEndPoint);
@@ -214,7 +223,7 @@ namespace MaxLib.WebServer
             if (KeepAliveConnections.Contains(connection))
                 KeepAliveConnections.Remove(connection);
             AllConnections.Remove(connection);
-            connection.NetworkClient.Close();
+            connection.NetworkClient?.Close();
         }
 
         internal protected virtual async Task ExecuteTaskChain(WebProgressTask task, ServerStage terminationState = ServerStage.FINAL_STAGE)
@@ -232,13 +241,13 @@ namespace MaxLib.WebServer
             }
         }
 
-        protected virtual WebProgressTask PrepairProgressTask(HttpConnection connection)
+        protected virtual WebProgressTask? PrepairProgressTask(HttpConnection connection)
         {
             var stream = connection.NetworkStream;
             if (stream == null)
                 try
                 {
-                    stream = connection.NetworkStream = connection.NetworkClient.GetStream();
+                    stream = connection.NetworkStream = connection.NetworkClient?.GetStream();
                 }
                 catch (InvalidOperationException)
                 { return null; }

--- a/MaxLib.WebServer/Server.cs
+++ b/MaxLib.WebServer/Server.cs
@@ -147,11 +147,13 @@ namespace MaxLib.WebServer
         protected virtual void ClientConnected(TcpClient client)
         {
             //prepare session
-            var connection = CreateRandomConnection();
-            connection.NetworkClient = client;
-            connection.Ip = client.Client.RemoteEndPoint is IPEndPoint iPEndPoint
-                ? iPEndPoint.Address.ToString()
-                : client.Client.RemoteEndPoint.ToString();
+            var connection = new HttpConnection()
+            {
+                NetworkClient = client,
+                Ip = client.Client.RemoteEndPoint is IPEndPoint iPEndPoint
+                    ? iPEndPoint.Address.ToString()
+                    : client.Client.RemoteEndPoint.ToString(),
+            };
             AllConnections.Add(connection);
             //listen to connection
             _ = Task.Run(async () => await SafeClientStartListen(connection));
@@ -250,18 +252,10 @@ namespace MaxLib.WebServer
             };
         }
 
+        [Obsolete("this method is no longer used by the server")]
         protected virtual HttpConnection CreateRandomConnection()
         {
-            var s = new HttpConnection();
-            var r = new Random();
-            do
-            {
-                s.ConnectionKey = new byte[16];
-                r.NextBytes(s.ConnectionKey);
-            }
-            while (AllConnections.Exists((ht) => ht != null && WebServerUtils.BytesEqual(ht.ConnectionKey, s.ConnectionKey)));
-            s.LastWorkTime = -1;
-            return s;
+            return new HttpConnection();
         }
     }
 }

--- a/MaxLib.WebServer/Server.cs
+++ b/MaxLib.WebServer/Server.cs
@@ -244,7 +244,6 @@ namespace MaxLib.WebServer
             {
                 CurrentStage = ServerStage.FIRST_STAGE,
                 NextStage = (ServerStage)((int)ServerStage.FIRST_STAGE + 1),
-                Document = new HttpDocument(),
                 Server = this,
                 Connection = connection,
                 NetworkStream = stream,

--- a/MaxLib.WebServer/Server.cs
+++ b/MaxLib.WebServer/Server.cs
@@ -193,7 +193,7 @@ namespace MaxLib.WebServer
 
                 await ExecuteTaskChain(task);
 
-                if (task.Document.RequestHeader.FieldConnection == HttpConnectionType.KeepAlive)
+                if (task.Request.FieldConnection == HttpConnectionType.KeepAlive)
                 {
                     if (!KeepAliveConnections.Contains(connection)) 
                         KeepAliveConnections.Add(connection);
@@ -244,11 +244,7 @@ namespace MaxLib.WebServer
             {
                 CurrentStage = ServerStage.FIRST_STAGE,
                 NextStage = (ServerStage)((int)ServerStage.FIRST_STAGE + 1),
-                Document = new HttpDocument
-                {
-                    RequestHeader = new HttpRequestHeader(),
-                    ResponseHeader = new HttpResponseHeader(),
-                },
+                Document = new HttpDocument(),
                 Server = this,
                 Connection = connection,
                 NetworkStream = stream,

--- a/MaxLib.WebServer/ServerLogAddedHandler.cs
+++ b/MaxLib.WebServer/ServerLogAddedHandler.cs
@@ -1,4 +1,6 @@
-﻿namespace MaxLib.WebServer
+﻿#nullable enable
+
+namespace MaxLib.WebServer
 {
     public delegate void ServerLogAddedHandler(ServerLogArgs eventArgs);
 }

--- a/MaxLib.WebServer/ServerLogArgs.cs
+++ b/MaxLib.WebServer/ServerLogArgs.cs
@@ -1,5 +1,7 @@
 ﻿using System;
 
+#nullable enable
+
 namespace MaxLib.WebServer
 {
     public class ServerLogArgs : EventArgs

--- a/MaxLib.WebServer/ServerLogItem.cs
+++ b/MaxLib.WebServer/ServerLogItem.cs
@@ -1,5 +1,7 @@
 ﻿using System;
 
+#nullable enable
+
 namespace MaxLib.WebServer
 {
     [Serializable]

--- a/MaxLib.WebServer/Services/Http404Service.cs
+++ b/MaxLib.WebServer/Services/Http404Service.cs
@@ -18,19 +18,19 @@ namespace MaxLib.WebServer.Services
 
         public override Task ProgressTask(WebProgressTask task)
         {
-            task.Document.ResponseHeader.StatusCode = HttpStateCode.NotFound;
+            task.Response.StatusCode = HttpStateCode.NotFound;
             var sb = new StringBuilder();
             sb.Append("<html><head><title>404 NOT FOUND</title></head>");
             sb.Append("<body><h1>Error 404: Not Found</h1><p>The requested resource is not found.</p>");
             sb.AppendLine("<pre>");
-            sb.AppendLine($"Protocol: {WebUtility.HtmlEncode(task.Document.RequestHeader.HttpProtocol)}");
-            sb.AppendLine($"Method:   {WebUtility.HtmlEncode(task.Document.RequestHeader.ProtocolMethod)}");
-            sb.AppendLine($"Url:      {WebUtility.HtmlEncode(task.Document.RequestHeader.Location.Url)}");
+            sb.AppendLine($"Protocol: {WebUtility.HtmlEncode(task.Request.HttpProtocol)}");
+            sb.AppendLine($"Method:   {WebUtility.HtmlEncode(task.Request.ProtocolMethod)}");
+            sb.AppendLine($"Url:      {WebUtility.HtmlEncode(task.Request.Location.Url)}");
             sb.AppendLine($"Header:");
-            foreach (var (key, value) in task.Document.RequestHeader.HeaderParameter)
+            foreach (var (key, value) in task.Request.HeaderParameter)
                 sb.AppendLine($"\t{WebUtility.HtmlEncode(key)}: {WebUtility.HtmlEncode(value)}");
             sb.AppendLine($"Body:");
-            sb.AppendLine(WebUtility.HtmlEncode(task.Document.RequestHeader.Post.CompletePost));
+            sb.AppendLine(WebUtility.HtmlEncode(task.Request.Post.CompletePost));
             sb.Append($"</pre><p>Try to change the request to get your expected response.</p>");
             sb.Append($"<small>Created by <a href=\"https://github.com/Garados007/MaxLib.WebServer\" " +
                 $"target=\"_blank\">MaxLib.WebServer</a>: {DateTime.UtcNow:r}</small></body></html>");

--- a/MaxLib.WebServer/Services/HttpDirectoryMapper.cs
+++ b/MaxLib.WebServer/Services/HttpDirectoryMapper.cs
@@ -61,12 +61,12 @@ namespace MaxLib.WebServer.Services
                     MimeType = GetMime(Path.GetExtension(path), task)
                 };
                 task.Document.DataSources.Add(source);
-                task.Document.ResponseHeader.StatusCode = HttpStateCode.OK;
+                task.Response.StatusCode = HttpStateCode.OK;
             }
             if (MapFolderToo && task.Document.Information.ContainsKey("HttpDocumentFolder"))
             {
                 var path = task.Document.Information["HttpDocumentFolder"].ToString();
-                var url = task.Document.RequestHeader.Location.DocumentPath.TrimEnd('/');
+                var url = task.Request.Location.DocumentPath.TrimEnd('/');
                 var d = new DirectoryInfo(path);
                 var html = "<html lang=\"de\"><head><title>" + d.Name + "</title></head><body>";
                 html += "<h1>" + path + "</h1><a href=\"../\">Eine Ebene h&ouml;her</a><ul>";
@@ -82,7 +82,7 @@ namespace MaxLib.WebServer.Services
                     MimeType = MimeType.TextHtml
                 };
                 task.Document.DataSources.Add(source);
-                task.Document.ResponseHeader.StatusCode = HttpStateCode.OK;
+                task.Response.StatusCode = HttpStateCode.OK;
             }
             await Task.CompletedTask;
         }

--- a/MaxLib.WebServer/Services/HttpDocumentFinder.cs
+++ b/MaxLib.WebServer/Services/HttpDocumentFinder.cs
@@ -69,7 +69,7 @@ namespace MaxLib.WebServer.Services
         {
             _ = task ?? throw new ArgumentNullException(nameof(task));
 
-            var path = task.Document.RequestHeader.Location.DocumentPathTiles;
+            var path = task.Request.Location.DocumentPathTiles;
             var rule = new List<Rule>();
             var level = -1;
             for (int i = 0; i < Rules.Count; ++i)
@@ -85,7 +85,7 @@ namespace MaxLib.WebServer.Services
             }
             foreach (var r in rule)
             {
-                var url = task.Document.RequestHeader.Location.DocumentPathTiles;
+                var url = task.Request.Location.DocumentPathTiles;
                 var p = r.LocalMappedPath;
                 for (int i = r.UrlMappedPath.Length; i < url.Length; ++i) p += "\\" + url[i];
                 if (r.File)

--- a/MaxLib.WebServer/Services/HttpHeaderPostParser.cs
+++ b/MaxLib.WebServer/Services/HttpHeaderPostParser.cs
@@ -23,7 +23,7 @@ namespace MaxLib.WebServer.Services
         {
             _ = task ?? throw new ArgumentNullException(nameof(task));
 
-            var header = task.Document.RequestHeader;
+            var header = task.Request;
             //Accept
             if (header.HeaderParameter.TryGetValue("Accept", out string value))
             {

--- a/MaxLib.WebServer/Services/HttpHeaderSpecialAction.cs
+++ b/MaxLib.WebServer/Services/HttpHeaderSpecialAction.cs
@@ -17,7 +17,7 @@ namespace MaxLib.WebServer.Services
         {
             _ = task ?? throw new ArgumentNullException(nameof(task));
 
-            switch (task.Document.RequestHeader.ProtocolMethod)
+            switch (task.Request.ProtocolMethod)
             {
                 case HttpProtocollMethod.Head:
                     task.Document.Information["Only Header"] = true;
@@ -42,7 +42,7 @@ namespace MaxLib.WebServer.Services
         {
             _ = task ?? throw new ArgumentNullException(nameof(task));
 
-            switch (task.Document.RequestHeader.ProtocolMethod)
+            switch (task.Request.ProtocolMethod)
             {
                 case HttpProtocollMethod.Head: return true;
                 case HttpProtocollMethod.Options: return true;

--- a/MaxLib.WebServer/Services/HttpResponseCreator.cs
+++ b/MaxLib.WebServer/Services/HttpResponseCreator.cs
@@ -18,8 +18,8 @@ namespace MaxLib.WebServer.Services
         {
             _ = task ?? throw new ArgumentNullException(nameof(task));
 
-            var request = task.Document.RequestHeader;
-            var response = task.Document.ResponseHeader;
+            var request = task.Request;
+            var response = task.Response;
             response.FieldContentType = task.Document.PrimaryMime;
             response.SetActualDate();
             response.HttpProtocol = request.HttpProtocol;

--- a/MaxLib.WebServer/Services/HttpSender.cs
+++ b/MaxLib.WebServer/Services/HttpSender.cs
@@ -90,7 +90,7 @@ namespace MaxLib.WebServer.Services
         {
             _ = task ?? throw new ArgumentNullException(nameof(task));
 
-            var header = task.Document.ResponseHeader;
+            var header = task.Response;
             var stream = task.NetworkStream;
             var writer = new StreamWriter(stream);
             await writer.WriteAsync(header.HttpProtocol);
@@ -105,7 +105,7 @@ namespace MaxLib.WebServer.Services
                 await writer.WriteAsync(": ");
                 await writer.WriteLineAsync(e.Value);
             }
-            foreach (var cookie in task.Document.RequestHeader.Cookie.AddedCookies) //Cookies
+            foreach (var cookie in task.Request.Cookie.AddedCookies) //Cookies
             {
                 await writer.WriteAsync("Set-Cookie: ");
                 await writer.WriteLineAsync(cookie.Value.ToString());

--- a/MaxLib.WebServer/Services/StandardDocumentLoader.cs
+++ b/MaxLib.WebServer/Services/StandardDocumentLoader.cs
@@ -30,7 +30,7 @@ namespace MaxLib.WebServer.Services
             {
                 MimeType = MimeType.TextHtml
             };
-            task.Document.ResponseHeader.StatusCode = HttpStateCode.OK;
+            task.Response.StatusCode = HttpStateCode.OK;
             task.Document.DataSources.Add(source);
             task.Document.PrimaryEncoding = "utf-8";
 

--- a/MaxLib.WebServer/Sessions/SessionServiceBase.cs
+++ b/MaxLib.WebServer/Sessions/SessionServiceBase.cs
@@ -25,12 +25,12 @@ namespace MaxLib.WebServer.Sessions
         public override async Task ProgressTask(WebProgressTask task)
         {
             _ = task ?? throw new ArgumentNullException(nameof(task));
-            var cookie = task.Document?.RequestHeader.Cookie.Get("Session");
+            var cookie = task.Request?.Cookie.Get("Session");
             string key;
             if (cookie == null)
             {
                 key = await GenerateSessionKey();
-                task.Document?.RequestHeader.Cookie.AddedCookies.Add("Session",
+                task.Request?.Cookie.AddedCookies.Add("Session",
                     new HttpCookie.Cookie(
                         "Session",
                         key,

--- a/MaxLib.WebServer/Testing/TestTask.cs
+++ b/MaxLib.WebServer/Testing/TestTask.cs
@@ -40,7 +40,7 @@ namespace MaxLib.WebServer.Testing
         /// Generate a random session and assign it to the task
         /// </summary>
         public void SetConnection()
-            => SetConnection(WebServer.CreateRandomConnection());
+            => SetConnection(new HttpConnection());
 
         public void SetConnection(HttpConnection connection)
         {

--- a/MaxLib.WebServer/Testing/TestTask.cs
+++ b/MaxLib.WebServer/Testing/TestTask.cs
@@ -77,22 +77,22 @@ namespace MaxLib.WebServer.Testing
             => Task.Document.Information.TryGetValue(key, out object value) ? value : default;
 
         public HttpStateCode GetStatusCode()
-            => Task.Document.ResponseHeader.StatusCode;
+            => Task.Response.StatusCode;
 
         public string GetRequestHeader(string key)
-            => Task.Document.RequestHeader.HeaderParameter.TryGetValue(key, out string value) ? value : default;
+            => Task.Request.HeaderParameter.TryGetValue(key, out string value) ? value : default;
 
         public string GetResponseHeader(string key)
-            => Task.Document.ResponseHeader.HeaderParameter.TryGetValue(key, out string value) ? value : default;
+            => Task.Response.HeaderParameter.TryGetValue(key, out string value) ? value : default;
 
         public IEnumerable<(string, HttpCookie.Cookie)> GetAddedCookies()
-            => Task.Document.RequestHeader.Cookie.AddedCookies
+            => Task.Request.Cookie.AddedCookies
                 .Select(p => (p.Key, p.Value));
 
         public HttpRequestHeader Request
-            => Task.Document.RequestHeader;
+            => Task.Request;
 
         public HttpResponseHeader Response
-            => Task.Document.ResponseHeader;
+            => Task.Response;
     }
 }

--- a/MaxLib.WebServer/Testing/TestWebServer.cs
+++ b/MaxLib.WebServer/Testing/TestWebServer.cs
@@ -56,6 +56,7 @@ namespace MaxLib.WebServer.Testing
         public new void RemoveConnection(HttpConnection connection)
             => base.RemoveConnection(connection);
 
+        [Obsolete("This method is no longer internaly used")]
         public new HttpConnection CreateRandomConnection()
             => base.CreateRandomConnection();
 

--- a/MaxLib.WebServer/WebProgressTask.cs
+++ b/MaxLib.WebServer/WebProgressTask.cs
@@ -7,7 +7,7 @@ namespace MaxLib.WebServer
 {
     public class WebProgressTask : IDisposable
     {
-        public HttpDocument? Document { get; set; }
+        public HttpDocument Document { get; } = new HttpDocument();
 
         public System.IO.Stream? NetworkStream { get; set; }
 
@@ -29,9 +29,9 @@ namespace MaxLib.WebServer
         public Sessions.Session? Session { get; set; }
 
 #pragma warning disable CS0618
-        public HttpRequestHeader? Request => Document?.RequestHeader;
+        public HttpRequestHeader Request => Document.RequestHeader;
 
-        public HttpResponseHeader? Response => Document?.ResponseHeader;
+        public HttpResponseHeader Response => Document.ResponseHeader;
 #pragma warning restore CS0618
 
         public void Dispose()

--- a/MaxLib.WebServer/WebProgressTask.cs
+++ b/MaxLib.WebServer/WebProgressTask.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿using System.Net;
+using System;
 
 #nullable enable
 
@@ -26,6 +27,12 @@ namespace MaxLib.WebServer
         public HttpConnection? Connection { get; set; }
 
         public Sessions.Session? Session { get; set; }
+
+#pragma warning disable CS0618
+        public HttpRequestHeader? Request => Document?.RequestHeader;
+
+        public HttpResponseHeader? Response => Document?.ResponseHeader;
+#pragma warning restore CS0618
 
         public void Dispose()
         {

--- a/MaxLib.WebServer/WebServerLog.cs
+++ b/MaxLib.WebServer/WebServerLog.cs
@@ -1,6 +1,8 @@
 ﻿using System;
 using System.Collections.Generic;
 
+#nullable enable
+
 namespace MaxLib.WebServer
 {
     public static class WebServerLog
@@ -11,12 +13,12 @@ namespace MaxLib.WebServer
         /// <summary>
         /// This event fires if some log item should be added. The log item can now filtered and discarded.
         /// </summary>
-        public static event ServerLogAddedHandler LogPreAdded;
+        public static event ServerLogAddedHandler? LogPreAdded;
 
         /// <summary>
         /// This event fires after a log item is added.
         /// </summary>
-        public static event Action<ServerLogItem> LogAdded;
+        public static event Action<ServerLogItem>? LogAdded;
 
         static readonly object lockObjekt = new object();
         public static void Add(ServerLogItem logItem)

--- a/MaxLib.WebServer/WebServerSettings.cs
+++ b/MaxLib.WebServer/WebServerSettings.cs
@@ -4,6 +4,8 @@ using System.Collections.Generic;
 using System.IO;
 using System.Net;
 
+#nullable enable
+
 namespace MaxLib.WebServer
 {
     public class WebServerSettings
@@ -23,7 +25,8 @@ namespace MaxLib.WebServer
         public bool Debug_WriteRequests = false;
         public bool Debug_LogConnections = false;
 
-        public Dictionary<string, string> DefaultFileMimeAssociation { get; } = new Dictionary<string, string>();
+        public Dictionary<string, string> DefaultFileMimeAssociation { get; } 
+            = new Dictionary<string, string>();
 
         protected enum SettingTypes
         {
@@ -31,7 +34,7 @@ namespace MaxLib.WebServer
             ServerSettings
         }
 
-        public string SettingsPath { get; private set; }
+        public string? SettingsPath { get; private set; }
 
         public virtual void LoadSettingFromData(string data)
         {

--- a/MaxLib.WebServer/WebServerTaskCreator.cs
+++ b/MaxLib.WebServer/WebServerTaskCreator.cs
@@ -2,6 +2,8 @@
 using System.IO;
 using System.Threading.Tasks;
 
+#nullable enable
+
 namespace MaxLib.WebServer
 {
     public class WebServerTaskCreator
@@ -50,7 +52,7 @@ namespace MaxLib.WebServer
             Task.Request.Post.SetPost(post, mime);
         }
 
-        public void SetAccept(string[] acceptTypes = null, string[] encoding = null)
+        public void SetAccept(string[]? acceptTypes = null, string[]? encoding = null)
         {
             if (acceptTypes != null) Task.Request.FieldAccept.AddRange(acceptTypes);
             if (encoding != null) Task.Request.FieldAcceptEncoding.AddRange(acceptTypes);

--- a/MaxLib.WebServer/WebServerTaskCreator.cs
+++ b/MaxLib.WebServer/WebServerTaskCreator.cs
@@ -18,7 +18,6 @@ namespace MaxLib.WebServer
                 Connection = new HttpConnection
                 {
                     Ip = "127.0.0.1",
-                    LastWorkTime = -1,
                 },
                 NetworkStream = new MemoryStream()
             };

--- a/MaxLib.WebServer/WebServerTaskCreator.cs
+++ b/MaxLib.WebServer/WebServerTaskCreator.cs
@@ -15,7 +15,6 @@ namespace MaxLib.WebServer
             Task = new WebProgressTask()
             {
                 CurrentStage = ServerStage.FIRST_STAGE,
-                Document = new HttpDocument(),
                 Connection = new HttpConnection
                 {
                     Ip = "127.0.0.1",

--- a/MaxLib.WebServer/WebServerTaskCreator.cs
+++ b/MaxLib.WebServer/WebServerTaskCreator.cs
@@ -15,11 +15,7 @@ namespace MaxLib.WebServer
             Task = new WebProgressTask()
             {
                 CurrentStage = ServerStage.FIRST_STAGE,
-                Document = new HttpDocument()
-                {
-                    RequestHeader = new HttpRequestHeader(),
-                    ResponseHeader = new HttpResponseHeader(),
-                },
+                Document = new HttpDocument(),
                 Connection = new HttpConnection
                 {
                     Ip = "127.0.0.1",
@@ -40,37 +36,37 @@ namespace MaxLib.WebServer
 
         public void SetProtocolHeader(string url, string method = "GET", string protocol = "HTTP/1.1")
         {
-            Task.Document.RequestHeader.ProtocolMethod = method;
-            Task.Document.RequestHeader.Url = url;
-            Task.Document.RequestHeader.HttpProtocol = protocol;
+            Task.Request.ProtocolMethod = method;
+            Task.Request.Url = url;
+            Task.Request.HttpProtocol = protocol;
         }
 
         public void SetHeaderParameter(string key, string value)
         {
-            if (Task.Document.RequestHeader.HeaderParameter.ContainsKey(key))
-                Task.Document.RequestHeader.HeaderParameter[key] = value;
-            else Task.Document.RequestHeader.HeaderParameter.Add(key, value);
+            if (Task.Request.HeaderParameter.ContainsKey(key))
+                Task.Request.HeaderParameter[key] = value;
+            else Task.Request.HeaderParameter.Add(key, value);
         }
 
         public void SetPost(string post, string mime)
         {
-            Task.Document.RequestHeader.Post.SetPost(post, mime);
+            Task.Request.Post.SetPost(post, mime);
         }
 
         public void SetAccept(string[] acceptTypes = null, string[] encoding = null)
         {
-            if (acceptTypes != null) Task.Document.RequestHeader.FieldAccept.AddRange(acceptTypes);
-            if (encoding != null) Task.Document.RequestHeader.FieldAcceptEncoding.AddRange(acceptTypes);
+            if (acceptTypes != null) Task.Request.FieldAccept.AddRange(acceptTypes);
+            if (encoding != null) Task.Request.FieldAcceptEncoding.AddRange(acceptTypes);
         }
 
         public void SetHost(string host)
         {
-            Task.Document.RequestHeader.Host = host;
+            Task.Request.Host = host;
         }
 
         public void SetCookie(string cookieString)
         {
-            Task.Document.RequestHeader.Cookie.SetRequestCookieString(cookieString);
+            Task.Request.Cookie.SetRequestCookieString(cookieString);
         }
 
         public void SetStream(Stream stream)

--- a/MaxLib.WebServer/WebServerTaskCreator.cs
+++ b/MaxLib.WebServer/WebServerTaskCreator.cs
@@ -19,7 +19,6 @@ namespace MaxLib.WebServer
                 {
                     Ip = "127.0.0.1",
                     LastWorkTime = -1,
-                    ConnectionKey = new byte[0],
                 },
                 NetworkStream = new MemoryStream()
             };

--- a/MaxLib.WebServer/WebServerUtils.cs
+++ b/MaxLib.WebServer/WebServerUtils.cs
@@ -2,6 +2,8 @@
 using System.Globalization;
 using System.Net;
 
+#nullable enable
+
 namespace MaxLib.WebServer
 {
     public static class WebServerUtils

--- a/MaxLib.WebServer/WebService.cs
+++ b/MaxLib.WebServer/WebService.cs
@@ -1,6 +1,8 @@
 ﻿using System;
 using System.Threading.Tasks;
 
+#nullable enable
+
 namespace MaxLib.WebServer
 {
     public abstract class WebService
@@ -17,7 +19,7 @@ namespace MaxLib.WebServer
 
         public abstract bool CanWorkWith(WebProgressTask task);
 
-        public event EventHandler ImportanceChanged;
+        public event EventHandler? ImportanceChanged;
 
         WebProgressImportance importance;
         public WebProgressImportance Importance

--- a/MaxLib.WebServer/WebServiceGroup.cs
+++ b/MaxLib.WebServer/WebServiceGroup.cs
@@ -2,6 +2,8 @@
 using System;
 using System.Threading.Tasks;
 
+#nullable enable
+
 namespace MaxLib.WebServer
 {
     public class WebServiceGroup
@@ -45,7 +47,7 @@ namespace MaxLib.WebServer
 
         private void Service_ImportanceChanged(object sender, EventArgs e)
         {
-            var service = sender as WebService;
+            var service = (WebService)sender;
             Services.ChangePriority(service.Importance, service);
         }
 
@@ -71,7 +73,7 @@ namespace MaxLib.WebServer
 
         public T Get<T>() where T : WebService
         {
-            return Services.Find((ws) => ws is T) as T;
+            return (T)Services.Find((ws) => ws is T);
         }
 
         public virtual async Task Execute(WebProgressTask task)
@@ -81,10 +83,10 @@ namespace MaxLib.WebServer
             var services = Services.ToArray();
             foreach (var service in services)
             {
-                if (task.Connection.NetworkClient != null && !task.Connection.NetworkClient.Connected) return;
+                if (task.Connection?.NetworkClient != null && !task.Connection.NetworkClient.Connected) return;
                 if (service.CanWorkWith(task))
                 {
-                    if (task.Connection.NetworkClient != null && !task.Connection.NetworkClient.Connected) return;
+                    if (task.Connection?.NetworkClient != null && !task.Connection.NetworkClient.Connected) return;
                     await service.ProgressTask(task);
                     task.Document[Stage] = true;
                     if (se) 

--- a/README.md
+++ b/README.md
@@ -1,2 +1,190 @@
 # MaxLib.WebServer
-A full web server written in C#
+
+[![.NET Core](https://github.com/Garados007/MaxLib.WebServer/workflows/.NET%20Core/badge.svg?branch=main)](https://github.com/Garados007/MaxLib.WebServer/actions?query=workflow%3A%22.NET+Core%22) 
+[![NuGet Publish](https://github.com/Garados007/MaxLib.WebServer/workflows/NuGet%20Publish/badge.svg)](https://www.nuget.org/packages?q=Garados007+MaxLib.WebServer) 
+[![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](https://github.com/Garados007/MaxLib.WebServer/blob/master/LICENSE) 
+[![Current Version](https://img.shields.io/github/tag/garados007/MaxLib.WebServer.svg?label=release)](https://github.com/Garados007/MaxLib.WebServer/releases) 
+![Top Language](https://img.shields.io/github/languages/top/garados007/MaxLib.WebServer.svg)
+
+`MaxLib.WebServer` is a full web server written in C#. To use this webserver you only need to add the .NuGet package to your project, instantiate the server in your code and thats it. No special configuration files or multiple processes.
+
+This web server is build modular. Any modules can be replaced by you and you decide what the server is cabable of. The server can fully configured (including exchanging the modules) during runtime - no need to restart everything.
+
+Some of the current features of the web server are:
+- HTTP web server (of course, that's the purpose of the project)
+- HTTPS web server with SSL certificates
+- HTTP and HTTPS web server on the same port. The server detects automaticly what the user intends to use.
+- Asynchronous handling of requests. Every part of the pipeline works with awaitable Tasks.
+- REST Api builder. You can directly bind your methods to the handlers.
+- Chunked transport. The server understands chunked datastreams and can produce these.
+- Lazy handling of requests. The server allows you to produce the content while you are sending the response. No need to wait.
+- Work with components that belongs to another AppDomain with Marshaling.
+- Deliver contents from your local drive (e.g. HDD)
+- Session keeping. You can identify the user later.
+- ...
+
+## Getting Started
+
+This will add MaxLib.WebServer to your project and create a basic server with basic functions.
+
+### Installing
+
+Add the `MaxLib.WebServer` package.
+
+```sh
+dotnet add package MaxLib.WebServer
+```
+
+### Create a simple server
+
+Write somewhere in your code (e.g.) in your Main method of your programm the following snippet:
+
+```csharp
+using MaxLib.WebServer;
+using MaxLib.WebServer.Services;
+
+// in your code 
+void SetupServer()
+{
+    // this expects that server is a variable that you have defined in your class
+    server = new Server(new WebServerSettings(
+        8000, // this will run the server on port 8000
+        5000  // set the timout to 5 seconds.
+    ));
+
+    // now add some services. You can use your own implementations but here we
+    // will add a basic set of services from MaxLib.WebServer.Services.
+
+    // this will read the request from the network stream
+    server.AddWebService(new HttpHeaderParser());
+    // this will read the header information and prepare them for later usage.
+    server.AddWebService(new HttpHeaderPostParser());
+    // this will take care of HTTP OPTIONS or HEAD requests
+    server.AddWebService(new HttpHeaderSpecialAction());
+    // this will serve 404 responses if no service has created a content for the request
+    server.AddWebService(new Http404Service());
+    // this will prepare the response headers before everything will be send to the user
+    server.AddWebService(new HttpResponseCreator());
+    // this will send the response to the user
+    server.AddWebService(new HttpSender());
+
+    // the server can now be startet. A basic set of services is defined so a new
+    // request will be handled and the user gets a response. Right now its a 
+    // 404 NOT FOUND but we will add more.
+    server.Start();
+
+    // if you don't need the server anymore you can close the server with
+    server.Stop();
+}
+
+```
+
+Right now you can start the server and open the url [http://localhost:8000](http://localhost:8000) in your browser and will get a nice 404 response.
+
+### Create own service
+
+Now we will create our own service, that will responds with a beatiful "Hello World" message.
+
+Create a new class `HelloWorldService` and put this code in it:
+
+```csharp
+using System;
+using System.Threading.Tasks;
+using MaxLib.WebServer;
+using MaxLib.WebServer.Services;
+
+// every service needs to be derived from WebService
+public class HelloWorldService : WebService
+{
+    public HelloWorldService()
+        // This will tell the server when this service should be executed.
+        : base(ServerStage.CreateDocument)
+    {
+        // This tells the priority this service will be executed in the current stage.
+        // right now we want the default normal priority.
+        Importance = WebProgressImportance.Normal; // optional
+    }
+
+    // the server asks every service in the current stage if they can do something
+    // with the current request. Right now we only want to act if the url is
+    // "/hello". This needs to be checked here.
+    public override bool CanWorkWith(WebProgressTask task)
+    {
+        // IsUrl checks if the path is "/hello" or "/hello/".
+        return task.Request.Location.IsUrl(new[] { "hello" });
+        // If you want to check for "/hello/world" you need to call:
+        // return task.Request.Location.IsUrl(new[] { "hello", "world" });
+    }
+
+    // this function will be called from the server only if CanWorkWith succeeds.
+    // Here we create our response
+    public override async Task ProgressTask(WebProgressTask task)
+    {
+        // Our response. In this case a simple html page.
+        var text = "<html><head><title>Hello World</title></head>" +
+            "<body><h1>Hello World!</h1></body></html>";
+        // now we add the result to the output. We can add any kind of data
+        // source. This library has the helper classes for strings, Streams
+        // and files.
+        task.Document.DataSources.Add(new HttpStringDataSource(text)
+        {
+            // this will specify the Mime-Type as "text/html". The static
+            // class MimeType contains many definitions but you can use your
+            // own here if you want. The default Mime-Type is "text/plain".
+            MimeType = MimeType.TextHtml,
+            // you can specify your encoding here. Default is "utf-8".
+            TextEncoding = "utf-8",
+        });
+        // we are now finished
+        await Task.CompletedTask;
+    }
+}
+```
+
+Now you need to add this line to add your service to server:
+
+```csharp
+server.AddWebService(new HelloWorldService());
+```
+
+After that you can run your programm and open the page [http://localhost:8000/hello](http://localhost:8000/hello). You will see your hello world message.
+
+## Example
+
+- [example/MaxLib.WebServer.Example](example/MaxLib.WebServer.Example)
+	- create a basic webserver
+
+## Contributing
+
+Please read [CONTRIBUTING.md](CONTRIBUTING.md) for details on our code of conduct, and the process for submitting pull requests to us.
+
+## Versioning
+
+We use [SemVer](semver.org) for versioning. For the versions available, see the [tags on this repository](https://github.com/Garados007/MaxLib.WebServer/tags).
+
+## Authors
+
+- **Max Brauer** - *Initial work* - [Garados007](https://github.com/Garados007)
+
+See also the list of [contributors](https://github.com/Garados007/srpc/contributors) who participated in this project.
+
+## Lincense
+
+This project is licensed under the MIT License  - see the [LICENSE.md](LICENSE.md) file for details
+
+## Acknowledgments
+
+- StackOverflow for the help
+- Wikipedia, SelfHTML and Mozilla for their documentation
+- [PurpleBooth](https://github.com/PurpleBooth) for her [README.md](https://gist.github.com/PurpleBooth/109311bb0361f32d87a2) template
+
+## Last Words
+
+This project was a free time project of mine and I have done it because why not. The source
+code was a long time a part of [MaxLib](https://github.com/Garados007/MaxLib) (a collection
+of other fun projects and code) but got its own repository for better maintenance.
+
+Some of the documentation inside the code is still in German and other things needs to be
+optimized.
+
+I have used this for some projects with my friends. It can handle some TB of traffic over a long period without any problems or crashes. I am a little proud of this.


### PR DESCRIPTION
- move Header fields from Document to `WebProgresTask`
- the Header fields at the Document are now deprecated but will still deliver the right information
    - this will be removed in a future release
- `WebProgressTask.Document` is now readonly
- the unused fields in `HttpConnection` are now removed
- `Server.CreateRandomConnection()` is now deprecated
- add pragma nullable to many classes and correct the nullable behaviour
- add a full text readme